### PR TITLE
feat(static_page):　文字列がからの時 'Ruby on Rails Tutorial Sample App'のみを表示

### DIFF
--- a/sample_app/app/helpers/application_helper.rb
+++ b/sample_app/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  
+  def full_title(page_title = '')
+    base_title = "Ruby on Rails Tutorial Sample App"
+    if page_title.empty?
+      base_title
+    else
+      page_title + " | " + base_title
+    end
+  end
 end

--- a/sample_app/app/views/layouts/application.html.erb
+++ b/sample_app/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | Ruby on Rails Tutorial Sample App</title>
+    <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/sample_app/app/views/static_pages/home.html.erb
+++ b/sample_app/app/views/static_pages/home.html.erb
@@ -1,9 +1,5 @@
-<% provide(:title,"Home") %>
 <!DOCTYPE html>
 <html>
-  <head>
-    <title><%= yield(:title)  %> | Ruby on Rails Tutorial Sample App</title>
-  </head>
   <body>
     <h1>Sample App</h1>
     <p>

--- a/sample_app/test/controllers/static_pages_controller_test.rb
+++ b/sample_app/test/controllers/static_pages_controller_test.rb
@@ -8,7 +8,7 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   test "should get home" do
     get static_pages_home_url
     assert_response :success
-    assert_select "title","Home | #{@base_title}"
+    assert_select "title","Ruby on Rails Tutorial Sample App"
   end
 
   test "should get help" do


### PR DESCRIPTION
## 概要
page_titleが空の時、"| Ruby on Rails Tutorial Sample App"と表示される

## 要件
- [x] page_titleが空の時,"Ruby on Rails Tutorial Sample App"と返すヘルパー関数の追加 